### PR TITLE
OCR:det 框数熔断,拦下纹理误检爆炸(修 #26)

### DIFF
--- a/src-tauri/src/ai/ocr.rs
+++ b/src-tauri/src/ai/ocr.rs
@@ -52,6 +52,13 @@ fn det_limit_side(tier: RecTier) -> u32 {
 const DET_THRESH: f32 = 0.3;
 const DET_BOX_THRESH: f32 = 0.6;
 const DET_UNCLIP: f32 = 1.5;
+/// det 输出框数熔断线。真实屏幕文字至多几百行(4K 全屏小字号终端 ~200 行,
+/// 密集表格几百行),超过它几乎必然是检测器对大面积纹理的误检爆炸——
+/// 实测一张 1328×826 的游戏海面截图(细密波纹)误检出的框让 prepare_units
+/// 裁出数十 GB 条带(单条最大 48×REC_MAX_W×3 ≈ 460KB),20 秒吃穿系统
+/// 提交上限拖死整机(issue #26)。超限按帧级错误处理而不是截断识别:
+/// 框全是噪声时"识别前 N 个"只会往索引里灌垃圾文本。
+const DET_MAX_BOXES: usize = 1000;
 /// rec 输入高;宽 = 高 × 纵横比,超过上限的超长行切段识别
 const REC_H: u32 = 48;
 const REC_MAX_W: u32 = 3200;
@@ -447,6 +454,14 @@ impl PaddleEngine {
         // 概率图 → 连通域 → 框(概率图按 pad 后尺寸索引);再按实际内容区映射回原图坐标
         let t_post = std::time::Instant::now();
         let mut boxes = prob_map_to_boxes(&prob, pw as usize, ph as usize);
+        // 误检爆炸熔断:必须在 prepare_units 裁条带之前拦下,框数无界 = 内存无界。
+        // 错误文本是 wire_code 的帧级分级标记,改措辞必须同步 ocr_worker.rs。
+        if boxes.len() > DET_MAX_BOXES {
+            return Err(Error::Ocr(format!(
+                "检测框数量异常: {} 框(熔断线 {DET_MAX_BOXES}),疑似大面积纹理误检",
+                boxes.len()
+            )));
+        }
         log::debug!(
             "det 分段: resize {resize_ms}ms + norm {norm_ms}ms + infer {infer_ms}ms + post {}ms",
             t_post.elapsed().as_millis()
@@ -776,6 +791,32 @@ mod tests {
         let boxes = prob_map_to_boxes(&prob, w, h);
         assert_eq!(boxes.len(), 2);
         assert!(boxes[0].x1 < boxes[1].x0);
+    }
+
+    /// 熔断线的存在依据:细碎纹理(水面波纹/噪点)在概率图上呈大量互不相连的
+    /// 高响应小块,连通域数量轻松破千——每框在 prepare_units 各裁一条最大
+    /// 48×REC_MAX_W×3 ≈ 460KB 的条带,无熔断时即 OOM(issue #26)。
+    /// 这里用 4×4 块阵模拟纹理响应,验证框数确实能远超 DET_MAX_BOXES。
+    #[test]
+    fn prob_map_texture_flood_exceeds_cap() {
+        let (w, h) = (200, 200);
+        let mut prob = vec![0f32; w * h];
+        // 每 5px 周期铺一个 4×4 高响应块:过 bw/bh≥3 与均值分双重过滤
+        for by in 0..40 {
+            for bx in 0..40 {
+                for dy in 0..4 {
+                    for dx in 0..4 {
+                        prob[(by * 5 + dy) * w + bx * 5 + dx] = 0.9;
+                    }
+                }
+            }
+        }
+        let boxes = prob_map_to_boxes(&prob, w, h);
+        assert!(
+            boxes.len() > DET_MAX_BOXES,
+            "块阵应产生 1600 框(> 熔断线 {DET_MAX_BOXES}),实际 {}",
+            boxes.len()
+        );
     }
 
     /// 真模型冒烟:需要 `<data_root>/ai/ocr/` 三件套 + onnxruntime 已安装。

--- a/src-tauri/src/ai/ocr_proto.rs
+++ b/src-tauri/src/ai/ocr_proto.rs
@@ -94,7 +94,8 @@ pub struct WireMsg {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrCode {
-    /// 图片读不出来(损坏/半写入/0 尺寸)
+    /// 确定可归责这张图的问题:读不出来(损坏/半写入/0 尺寸),或内容令
+    /// 检测器误检爆炸(det 框数熔断,见 ocr.rs 的 DET_MAX_BOXES)
     Decode,
     /// 引擎推理失败(这一张的问题)
     Engine,

--- a/src-tauri/src/ai/ocr_worker.rs
+++ b/src-tauri/src/ai/ocr_worker.rs
@@ -114,12 +114,19 @@ impl Watchdog {
 ///   截图随保留策略删除,文字不可恢复。
 ///
 /// 判据是错误文本标记("读图失败" = Paddle 解码;"zero-dimension" = Vision
-/// 对 0 尺寸图的报错)——脆弱但生成点都在本仓库内且有测试钉住,
-/// 改动生成点必须同步这里。
+/// 对 0 尺寸图的报错;"检测框数量异常" = det 误检爆炸熔断)——脆弱但生成点
+/// 都在本仓库内且有测试钉住,改动生成点必须同步这里。
 fn wire_code(e: &Error) -> ErrCode {
     match e {
         Error::EmbeddingRuntimeMissing => ErrCode::RuntimeMissing,
-        Error::Ocr(s) if s.contains("读图失败") || s.contains("zero-dimension") => {
+        // "检测框数量异常" = det 误检爆炸熔断(ocr.rs):虽发生在推理后,但归责
+        // 与解码失败同路——确定是这张图的问题,必须烧帧,否则毒帧无限重试
+        // 堵死整个队列(issue #26 的第二半)。
+        Error::Ocr(s)
+            if s.contains("读图失败")
+                || s.contains("zero-dimension")
+                || s.contains("检测框数量异常") =>
+        {
             ErrCode::Decode
         }
         _ => ErrCode::Engine,
@@ -375,6 +382,20 @@ mod tests {
         served.unwrap();
         assert_eq!(msgs[0].code, Some(ErrCode::Decode), "读图失败 → 帧级");
         assert_eq!(msgs[1].code, Some(ErrCode::Engine), "推理错误 → 设施级");
+    }
+
+    /// det 误检爆炸熔断(ocr.rs 的 DET_MAX_BOXES)必须按帧级归责:
+    /// 归成设施级(Engine)就不烧帧预算,毒帧会永远排在队首无限重试,
+    /// 整个识别队列被一张图堵死(issue #26 实际发生,停摆约 24 小时)。
+    /// 钉的是 wire_code 的文本标记匹配——ocr.rs 改错误措辞会在这里断。
+    #[test]
+    fn box_flood_fuse_graded_as_frame_level() {
+        let e = Error::Ocr("检测框数量异常: 48231 框(熔断线 1000),疑似大面积纹理误检".into());
+        assert_eq!(
+            wire_code(&e),
+            ErrCode::Decode,
+            "误检爆炸 → 帧级,烧预算后放行队列"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
修复 #26:一张大面积纹理截图(游戏海面波纹)会让 det 误检出海量文本框,
`prepare_units` 随之为每框裁条带(单条最大 48×REC_MAX_W×3 ≈ 460KB),
数万框 = 数十 GB,20 秒内吃穿系统提交上限拖死整机。实测两轮
(DirectML / 强制 CPU)峰值 27.75 / 40.45 GB,曲线几乎重叠——
问题在推理**之前**的纯 CPU 后处理,与执行后端无关。

## 修法:框数熔断 + 帧级归责

**`ocr.rs`** — `detect()` 在 `prob_map_to_boxes` 之后、`prepare_units`
之前检查框数,超过 `DET_MAX_BOXES = 1000` 直接返回帧级 `Error::Ocr`。
真实屏幕文字至多几百行(4K 全屏小字号终端 ~200 行),破千几乎必然是
纹理误检。**不做截断识别**:框全是噪声时"识别前 N 个"只会往索引灌垃圾。

**`ocr_worker.rs`** — `wire_code` 把"检测框数量异常"标记归入
`ErrCode::Decode`(帧级)。这半边同样关键:不加的话该错误落进
`_ => Engine` 兜底 → 父进程按设施处理、不烧帧预算 → 毒帧永远排在
`ORDER BY ts ASC` 队首无限重试——#26 里"队列停摆约 24 小时"的第二半
成因。归入帧级后走既有重试机制:烧 3 次 `attempts` 后标失败退场,
队列继续前进,无需任何新逻辑。

**`ocr_proto.rs`** — 仅补 `Decode` 的语义注释(复用现有码,协议不变:
worker 与父进程是同一 exe 重入,不存在新老版本搭配)。

## 为什么选内容阈值而不是内存阈值

框数上限是**图像内容语义**的阈值——"一张截图上最多有多少真实文字行",
与机器配置无关,任何机器上 1000 都是同一含义。相比之下,给 worker 加
内存上限(Job Object / 采样杀进程)绕不开 per-machine 阈值语义的取舍,
且只能事后止损;熔断在分配发生前拦截,那一帧的 det 结果直接作废,
不产生任何大分配。(内存兜底作为纵深防御仍可另行讨论,见 #26 建议 2/3。)

## 测试

- `prob_map_texture_flood_exceeds_cap`(ocr.rs):4×4 块阵模拟纹理响应,
  验证连通域数量确实能远超熔断线——熔断存在依据的回归文档。
- `box_flood_fuse_graded_as_frame_level`(ocr_worker.rs):钉住文本标记
  归责为 `Decode`;ocr.rs 改错误措辞会在这里断,与既有
  `decode_error_graded_separately_from_engine_error` 同一钉法。

验证:`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` /
`cargo test` 全绿。

毒帧原件已保留(108KB,可提供),删除它后同一批积压 726 帧全部正常清完
——熔断线之下的真实场景不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
