### PR TITLE
refactor(capture): rename privacy to screenshot_policy

### DIFF
--- a/src-tauri/src/ai/summary_operations.rs
+++ b/src-tauri/src/ai/summary_operations.rs
@@ -14,7 +14,7 @@ use crate::ai::config::AiConfig;
 use crate::ai::llm::{ChatClient, ExternalChatClient, Step2Chat};
 use crate::ai::prompt::{build_system_prompt, build_user_prompt, SegmentContext};
 use crate::ai::server::EngineSupervisor;
-use crate::capture::privacy;
+use crate::capture::screenshot_policy;
 use crate::error::{Error, Result};
 use crate::repo::ai_summaries::{self, SegmentSummaryRow};
 use crate::repo::reports::DeviceFilter;
@@ -315,7 +315,7 @@ fn format_timeline_hours(
         if let Some(t) = title {
             let trimmed = t.trim();
             if !trimmed.is_empty() {
-                let display = if privacy::matches_any(trimmed, privacy_app_keywords) {
+                let display = if screenshot_policy::matches_any(trimmed, privacy_app_keywords) {
                     "[私密]".to_string()
                 } else {
                     trimmed.to_string()

--- a/src-tauri/src/capture/browser_url/mod.rs
+++ b/src-tauri/src/capture/browser_url/mod.rs
@@ -12,7 +12,7 @@
 //! 调用方包 `spawn_blocking`，不要在 async runtime 直接调。
 //!
 //! 拿不到 URL（未授权 / 浏览器没开 / 平台不支持）一律返回 None；URL 关键词
-//! 那一路在 `privacy::should_skip_screenshot` 里会自动跳过，不影响 app/标题
+//! 那一路在 `screenshot_policy::should_skip_screenshot` 里会自动跳过，不影响 app/标题
 //! 关键词匹配。
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/capture/ignore.rs
+++ b/src-tauri/src/capture/ignore.rs
@@ -1,44 +1,40 @@
-//! 忽略规则：决定一条活动行是否**计入统计**。
+//! Ignore rules decide whether an activity counts towards the stats. A match
+//! sets `excluded = 1`, and reports, exports, AI summaries and chat queries all
+//! skip the row — but it is still stored, still screenshotted, and still
+//! uploaded.
 //!
-//! 与 [`super::privacy`] 的区别（两者正交，容易混）：
-//! - privacy 管"要不要截图"——命中则不存图，但活动行照常入库、照常计时；
-//! - 本模块管"算不算时长"——命中则活动行照常入库、照常截图，但 `excluded = 1`，
-//!   所有报表 / 导出 / AI 总结 / chat 查询都跳过它。
+//! Easy to confuse with [`super::screenshot_policy`]; the two are orthogonal.
+//! That one decides whether to keep a screenshot, and time is counted either way.
 //!
-//! 语义等同内建 `hidden` 分类，只是粒度细到**窗口标题**：`hidden` 归的是整个应用，
-//! 这里能只排除某个应用下的某类窗口（典型场景：终端里挂机跑下载，终端本身要留）。
-//!
-//! 可逆：规则删掉后跑一次 [`crate::repo::activities::reapply_ignore_rules`]
-//! 重算全表，历史数据重新计入。
+//! Reversible: delete the rule and run
+//! [`crate::repo::activities::reapply_ignore_rules`] to recompute the flag over
+//! the whole table, and the history counts again.
 
 use serde::{Deserialize, Serialize};
 
-/// 一条忽略规则 = 进程名（精确）+ 窗口标题关键词（子串，可选）。
+/// One ignore rule: a process name (required) plus an optional window-title
+/// keyword. Matched activities are still recorded and still get a screenshot;
+/// only stats, exports and AI summaries skip them.
 ///
-/// 为什么必须带进程名、不允许"纯标题关键词"：标题关键词单独生效的话，
-/// 用户填一个 `Download` 就会把所有应用里带这个词的窗口一起吞掉，
-/// 而被吞掉的时长不报错、不提示，只是统计对不上——静默丢数据是这类
-/// 功能最容易出的事故。
+/// A bare keyword is not allowed: "Download" on its own would swallow matching
+/// windows across every app, with no error and no hint.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct IgnoreRule {
-    /// 进程名。精确匹配，忽略大小写、忽略首尾空白。
+    /// Process name. Exact match, case-insensitive, trimmed.
     pub process_name: String,
-    /// 窗口标题关键词。子串匹配，忽略大小写。
+    /// Window-title keyword: the title must contain it, case-insensitive.
+    /// `None` excludes the whole process.
     ///
-    /// `None` = 整个进程都不计入统计（即 RemoveAppDialog 注释里提到、但一直
-    /// 没实现的「不再记录」的统计版）。
-    ///
-    /// 注意 `Some("")` / `Some("   ")` **不等于** `None`：全空白关键词一律不命中。
-    /// 因为 `contains("")` 恒为 true，把空串当"匹配一切"会让一次 UI 手滑
-    /// 静默排除整个应用；想排除整个应用必须显式传 `None`。
+    /// A blank keyword never matches. Every string contains the empty string,
+    /// so matching literally would exclude the whole app the moment the UI
+    /// sends `Some("")` for an input box the user left empty.
     #[serde(default)]
     pub title_keyword: Option<String>,
 }
 
-/// 当前窗口是否命中任一规则 → 该活动行不计入统计。
-///
-/// 空列表 = 不排除任何东西。
+/// Whether the current window matches any rule, i.e. whether this activity is
+/// left out of the stats. An empty rule list excludes nothing.
 pub fn is_excluded(app_name: &str, title: &str, rules: &[IgnoreRule]) -> bool {
     if rules.is_empty() {
         return false;
@@ -51,16 +47,16 @@ pub fn is_excluded(app_name: &str, title: &str, rules: &[IgnoreRule]) -> bool {
 
     rules.iter().any(|rule| {
         let want = rule.process_name.trim().to_lowercase();
-        // 空进程名的规则视为无效：否则它会匹配所有窗口。
+        // A rule with no process name is invalid: it would match every window.
         if want.is_empty() || want != app {
             return false;
         }
         match rule.title_keyword.as_deref() {
-            // 无标题条件 = 整个进程
+            // No title condition: the whole process.
             None => true,
             Some(kw) => {
                 let kw = kw.trim().to_lowercase();
-                // 全空白关键词不命中（见字段文档）
+                // A blank keyword never matches (see the field doc).
                 !kw.is_empty() && title_lower.contains(&kw)
             }
         }

--- a/src-tauri/src/capture/mod.rs
+++ b/src-tauri/src/capture/mod.rs
@@ -2,10 +2,10 @@ pub mod browser_url;
 #[cfg(target_os = "macos")]
 pub mod bundle;
 pub mod ignore;
-pub mod privacy;
 pub mod screenshot;
 #[cfg(target_os = "macos")]
 pub mod screenshot_macos;
+pub mod screenshot_policy;
 pub mod service;
 pub mod window;
 

--- a/src-tauri/src/capture/screenshot_policy.rs
+++ b/src-tauri/src/capture/screenshot_policy.rs
@@ -1,34 +1,23 @@
-//! 隐私过滤：决定本次焦点切换是否要保存截图。
+//! Screenshot policy: decides whether this focus switch gets a screenshot saved.
+//! Backend of the "Privacy" section in settings.
 //!
-//! 命中即跳过截图，活动行 / 应用名 / 时长照常记录。
-//!
-//! 两类关键词：
-//! - **URL 关键词**：浏览器地址栏 URL 子串忽略大小写匹配。url 为 None 时这一路不参与判断
-//! - **应用关键词**：app_name 或窗口标题 子串忽略大小写匹配
-//!
-//! 任意一路命中即跳过。两组列表都为空 = 不过滤。
+//! A match only skips the screenshot — the activity row is still stored, still
+//! timed, and still uploaded. Whether it counts towards the stats is
+//! [`super::ignore`]'s job; the two are orthogonal.
 
-/// 任意关键词命中（子串忽略大小写）即返回 true。
+/// Whether to skip this screenshot: the URL matches `url_keywords`, or the app
+/// name or window title matches `window_keywords`. Substring, case-insensitive;
+/// an empty list or a missing URL simply never matches.
 pub fn should_skip_screenshot(
     app_name: &str,
     title: &str,
     url: Option<&str>,
     url_keywords: &[String],
-    app_keywords: &[String],
+    window_keywords: &[String],
 ) -> bool {
-    if !url_keywords.is_empty() {
-        if let Some(u) = url {
-            if matches_any(u, url_keywords) {
-                return true;
-            }
-        }
-    }
-    if !app_keywords.is_empty()
-        && (matches_any(app_name, app_keywords) || matches_any(title, app_keywords))
-    {
-        return true;
-    }
-    false
+    url.is_some_and(|u| matches_any(u, url_keywords))
+        || matches_any(app_name, window_keywords)
+        || matches_any(title, window_keywords)
 }
 
 pub(crate) fn matches_any(haystack: &str, keywords: &[String]) -> bool {

--- a/src-tauri/src/capture/service.rs
+++ b/src-tauri/src/capture/service.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-use crate::capture::{browser_url, ignore, privacy, screenshot, window};
+use crate::capture::{browser_url, ignore, screenshot, screenshot_policy, window};
 use crate::error::Result;
 use crate::memory::{frames as memory_frames, MemoryDb};
 use crate::repo::settings::TimeRange;
@@ -795,7 +795,7 @@ async fn should_skip_for_privacy(
     if is_browser && url.is_none() && !url_kw.is_empty() {
         return true;
     }
-    privacy::should_skip_screenshot(&info.app_name, &info.title, url, &url_kw, &app_kw)
+    screenshot_policy::should_skip_screenshot(&info.app_name, &info.title, url, &url_kw, &app_kw)
 }
 
 /// 截图后的隐私复核：按"现在"的窗口标题（浏览器再抓一次 URL）重跑同一套隐私规则。

--- a/src-tauri/src/repo/categories.rs
+++ b/src-tauri/src/repo/categories.rs
@@ -186,15 +186,16 @@ pub async fn create(pool: &DbPool, input: CategoryInput) -> Result<Category> {
 
     let cat = pool.0
         .call(move |conn| {
+            let tx = conn.transaction().db()?;
             // New category will be placed at the end: sort_order = max(active sort_order) + 1
-            let next_sort: i64 = conn
+            let next_sort: i64 = tx
                 .query_row(
                     "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM categories WHERE deleted_at IS NULL",
                     [],
                     |r| r.get(0),
                 )
                 .db()?;
-            conn.execute(
+            tx.execute(
                 "INSERT INTO categories(id, name, color, icon, builtin, sort_order, updated_at)
                  VALUES(?, ?, ?, ?, 0, ?, ?)",
                 rusqlite::params![id, n, c, i, next_sort, &updated],
@@ -202,8 +203,9 @@ pub async fn create(pool: &DbPool, input: CategoryInput) -> Result<Category> {
             .db()?;
 
             let payload = category_payload(&id, &n, &c, &i, false, next_sort, &updated, None);
-            enqueue(conn, OutboxOp::Upsert, OutboxEntity::Category, &id, &payload)
+            enqueue(&tx, OutboxOp::Upsert, OutboxEntity::Category, &id, &payload)
                 .db()?;
+            tx.commit().db()?;
             Ok(Category {
                 id,
                 name: n,


### PR DESCRIPTION
Two unrelated-looking changes that came out of reading `capture/`.

## `privacy` was the wrong name

The module decides one thing: whether this focus switch gets a screenshot saved. Calling it `privacy` promised a scope it does not have — the activity row is still stored, still timed, and still uploaded — and that is exactly the misreading it produced while reading the code.

`screenshot.rs` takes the shot; `screenshot_policy.rs` decides whether to.

Smaller things that came with it:

- Its keyword list matches the app name **and** the window title, so `app_keywords` became `window_keywords`, pairing with `url_keywords`.
- Both `is_empty` guards are gone: `matches_any` already returns false for an empty list, so they never prevented anything. The body is now the boolean expression its doc describes rather than the same thing spelled as control flow.
- Module headers for `screenshot_policy` and `ignore` rewritten. Both now say the thing that was missing and that I got wrong while reading: a match here changes what is captured or counted, **not** what is uploaded.

The `privacy_url_keywords` and `privacy_app_keywords` settings fields deliberately keep their names — they serialise into the user's stored settings, and a migration addresses that JSON path.

## Creating a category was not atomic

`create` wrote the row and then enqueued the outbox entry with no transaction around them. If the enqueue failed, the category existed but sync never heard about it, and retrying created a second one under a new UUID.

The other write paths in `categories.rs` have the same gap. A `with_tx` helper that makes the pairing structural is the follow-up, tracked in `app_groups.rs`.

## Checked

`cargo test` 523 passed · `clippy --all-targets -D warnings` clean · `cargo fmt --check` clean · `npm run lint` at its 2-warning budget. The first commit compiles on its own, so bisect stays usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
