### PR TITLE
fix(repo,sync): stop silent write failures in category and group writes

### DIFF
--- a/src-tauri/src/repo/app_groups.rs
+++ b/src-tauri/src/repo/app_groups.rs
@@ -620,46 +620,58 @@ pub async fn unmerge(pool: &DbPool, process_name: &str) -> Result<()> {
 /// its user-defined display name and updates only its category, timestamp, and
 /// deletion state.
 ///
-/// Both the group and member changes are queued for sync.
+/// Both the group and member changes are queued for sync. Takes a transaction
+/// rather than a connection: the two rows and their two outbox entries have to
+/// land together or not at all, and the parameter type is what enforces it.
 fn restore_solo_group(
-    conn: &Connection,
+    tx: &rusqlite::Transaction<'_>,
     process_name: &str,
     category_id: Option<&str>,
     updated_at: &str,
 ) -> rusqlite::Result<()> {
-    conn.execute(
+    // `WHERE` on the conflict branch: a live group that already carries this
+    // category is left alone, so its `updated_at` is not bumped for nothing.
+    let n = tx.execute(
         "INSERT INTO app_groups(id, display_name, category_id, updated_at, deleted_at)
          VALUES(?, ?, ?, ?, NULL)
          ON CONFLICT(id) DO UPDATE SET
            category_id  = excluded.category_id,
            updated_at   = excluded.updated_at,
-           deleted_at   = NULL",
+           deleted_at   = NULL
+         WHERE app_groups.deleted_at IS NOT NULL
+            OR app_groups.category_id IS NOT excluded.category_id",
         rusqlite::params![process_name, process_name, category_id, updated_at],
     )?;
-    enqueue(
-        conn,
-        OutboxOp::Upsert,
-        OutboxEntity::AppGroup,
-        process_name,
-        &serde_json::json!({ "groupId": process_name }).to_string(),
-    )?;
+    if n > 0 {
+        enqueue(
+            tx,
+            OutboxOp::Upsert,
+            OutboxEntity::AppGroup,
+            process_name,
+            &serde_json::json!({ "groupId": process_name }).to_string(),
+        )?;
+    }
 
-    conn.execute(
+    let n = tx.execute(
         "INSERT INTO app_group_members(process_name, group_id, updated_at, deleted_at)
          VALUES(?, ?, ?, NULL)
          ON CONFLICT(process_name) DO UPDATE SET
            group_id   = excluded.group_id,
            updated_at = excluded.updated_at,
-           deleted_at = NULL",
+           deleted_at = NULL
+         WHERE app_group_members.deleted_at IS NOT NULL
+            OR app_group_members.group_id IS NOT excluded.group_id",
         rusqlite::params![process_name, process_name, updated_at],
     )?;
-    enqueue(
-        conn,
-        OutboxOp::Upsert,
-        OutboxEntity::AppGroupMember,
-        process_name,
-        &serde_json::json!({ "processName": process_name }).to_string(),
-    )?;
+    if n > 0 {
+        enqueue(
+            tx,
+            OutboxOp::Upsert,
+            OutboxEntity::AppGroupMember,
+            process_name,
+            &serde_json::json!({ "processName": process_name }).to_string(),
+        )?;
+    }
 
     Ok(())
 }
@@ -674,20 +686,27 @@ pub async fn rename(pool: &DbPool, group_id: &str, new_name: &str) -> Result<()>
     pool.0
         .call(move |conn| {
             let tx = conn.transaction().db()?;
-            tx.execute(
-                "UPDATE app_groups SET display_name = ?2, updated_at = ?3
-                 WHERE id = ?1",
-                rusqlite::params![id, name, updated_at],
-            )
-            .db()?;
-            enqueue(
-                &tx,
-                OutboxOp::Upsert,
-                OutboxEntity::AppGroup,
-                &id,
-                &serde_json::json!({ "groupId": id }).to_string(),
-            )
-            .db()?;
+            // `display_name IS NOT ?2` makes renaming to the current name a no-op.
+            // `updated_at` arbitrates last-write-wins, so it has to mean "the content
+            // changed", not "the row was written": bumping it for an unchanged name
+            // would win the comparison against a peer that really did rename it.
+            let n = tx
+                .execute(
+                    "UPDATE app_groups SET display_name = ?2, updated_at = ?3
+                     WHERE id = ?1 AND display_name IS NOT ?2",
+                    rusqlite::params![id, name, updated_at],
+                )
+                .db()?;
+            if n > 0 {
+                enqueue(
+                    &tx,
+                    OutboxOp::Upsert,
+                    OutboxEntity::AppGroup,
+                    &id,
+                    &serde_json::json!({ "groupId": id }).to_string(),
+                )
+                .db()?;
+            }
             tx.commit().db()?;
             Ok(())
         })
@@ -733,20 +752,27 @@ pub async fn assign_category(
     pool.0
         .call(move |conn| {
             let tx = conn.transaction().db()?;
-            tx.execute(
-                "UPDATE app_groups SET category_id = ?2, updated_at = ?3
-                 WHERE id = ?1",
-                rusqlite::params![id, cat, now],
-            )
-            .db()?;
-            enqueue(
-                &tx,
-                OutboxOp::Upsert,
-                OutboxEntity::AppGroup,
-                &id,
-                &serde_json::json!({ "groupId": id }).to_string(),
-            )
-            .db()?;
+            // `category_id IS NOT ?2` makes re-assigning the same category a no-op,
+            // clearing an already-cleared one included — `IS NOT` is NULL-safe, `!=`
+            // is not. See `rename` for why an unchanged write must not bump
+            // `updated_at`.
+            let n = tx
+                .execute(
+                    "UPDATE app_groups SET category_id = ?2, updated_at = ?3
+                     WHERE id = ?1 AND category_id IS NOT ?2",
+                    rusqlite::params![id, cat, now],
+                )
+                .db()?;
+            if n > 0 {
+                enqueue(
+                    &tx,
+                    OutboxOp::Upsert,
+                    OutboxEntity::AppGroup,
+                    &id,
+                    &serde_json::json!({ "groupId": id }).to_string(),
+                )
+                .db()?;
+            }
 
             tx.commit().db()?;
             Ok(())

--- a/src-tauri/src/repo/categories.rs
+++ b/src-tauri/src/repo/categories.rs
@@ -296,23 +296,24 @@ pub async fn reorder(pool: &DbPool, ordered_ids: Vec<String>) -> Result<()> {
     let updated_at = utc_now_rfc3339();
     pool.0
         .call(move |conn| {
+            let tx = conn.transaction().db()?;
             for (idx, id) in ordered_ids.iter().enumerate() {
                 let new_sort = idx as i64;
-                let row: Option<(String, String, String, i64, i64)> = conn
+                let row: Option<(String, String, String, i64, i64)> = tx
                     .query_row(
                         "SELECT name, color, icon, builtin, sort_order FROM categories
                          WHERE id = ?1 AND deleted_at IS NULL",
                         rusqlite::params![id],
                         |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
                     )
-                    .ok(); // TODO: Create a proper error if the category is not found.
+                    .optional()?;
                 let Some((name, color, icon, builtin_i, cur_sort)) = row else {
                     continue;
                 };
                 if cur_sort == new_sort {
                     continue; // Don't need to update if the sort order hasn't changed
                 }
-                conn.execute(
+                tx.execute(
                     "UPDATE categories SET sort_order = ?1, updated_at = ?2
                      WHERE id = ?3 AND deleted_at IS NULL",
                     rusqlite::params![new_sort, updated_at, id],
@@ -328,8 +329,9 @@ pub async fn reorder(pool: &DbPool, ordered_ids: Vec<String>) -> Result<()> {
                     &updated_at,
                     None,
                 );
-                enqueue(conn, OutboxOp::Upsert, OutboxEntity::Category, id, &payload).db()?;
+                enqueue(&tx, OutboxOp::Upsert, OutboxEntity::Category, id, &payload).db()?;
             }
+            tx.commit().db()?;
             Ok(())
         })
         .await?;
@@ -358,14 +360,15 @@ pub async fn delete(pool: &DbPool, id: &str) -> Result<()> {
     let outcome: std::result::Result<(), &'static str> = pool
         .0
         .call(move |conn| {
-            let row: Option<(String, String, String, i64, i64)> = conn
+            let tx = conn.transaction().db()?;
+            let row: Option<(String, String, String, i64, i64)> = tx
                 .query_row(
                     "SELECT name, color, icon, builtin, sort_order FROM categories
                      WHERE id = ? AND deleted_at IS NULL",
                     rusqlite::params![id],
                     |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
                 )
-                .ok(); // TODO: Create a proper error if the category is not found?
+                .optional()?;
             let Some((name, color, icon, builtin_i, sort_order)) = row else {
                 return Ok(Ok(()));
             };
@@ -381,7 +384,7 @@ pub async fn delete(pool: &DbPool, id: &str) -> Result<()> {
                 ));
             }
 
-            conn.execute(
+            tx.execute(
                 "UPDATE categories SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
                 rusqlite::params![updated_at, id],
             )
@@ -398,7 +401,7 @@ pub async fn delete(pool: &DbPool, id: &str) -> Result<()> {
                 Some(&updated_at),
             );
             enqueue(
-                conn,
+                &tx,
                 OutboxOp::Upsert,
                 OutboxEntity::Category,
                 &id,
@@ -406,8 +409,9 @@ pub async fn delete(pool: &DbPool, id: &str) -> Result<()> {
             )
             .db()?;
 
-            cascade_category_deletion(conn, &id, &updated_at)?;
+            cascade_category_deletion(&tx, &id, &updated_at)?;
 
+            tx.commit().db()?;
             Ok(Ok(()))
         })
         .await?;
@@ -420,6 +424,10 @@ pub async fn delete(pool: &DbPool, id: &str) -> Result<()> {
 ///
 /// Idempotent: every UPDATE is guarded, so a repeat run touches zero rows and
 /// enqueues nothing.
+///
+/// Expects to be called inside a transaction: the tombstone that triggered it
+/// and every group this clears have to land together. The parameter type does
+/// not enforce that yet.
 pub fn cascade_category_deletion(
     conn: &Connection,
     category_id: &str,
@@ -1223,7 +1231,9 @@ mod tests {
         let cid = cat.id.clone();
         pool.0
             .call(move |conn| {
-                cascade_category_deletion(conn, &cid, "2026-07-26T00:00:00Z")?;
+                let tx = conn.transaction()?;
+                cascade_category_deletion(&tx, &cid, "2026-07-26T00:00:00Z")?;
+                tx.commit()?;
                 Ok(())
             })
             .await

--- a/src-tauri/src/repo/categories.rs
+++ b/src-tauri/src/repo/categories.rs
@@ -7,7 +7,7 @@
 //! its groups back to unclassified; built-in categories and `other` cannot be
 //! deleted, since unclassified time needs somewhere to land.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -230,14 +230,15 @@ pub async fn update(pool: &DbPool, id: &str, patch: CategoryPatch) -> Result<()>
     pool.0
         .call(move |conn| {
             // 读出当前行做基线
-            let row: Option<(String, String, String, i64, i64)> = conn
+            let tx = conn.transaction().db()?;
+            let row: Option<(String, String, String, i64, i64)> = tx
                 .query_row(
                     "SELECT name, color, icon, builtin, sort_order FROM categories
                      WHERE id = ? AND deleted_at IS NULL",
                     rusqlite::params![id],
                     |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
                 )
-                .ok(); // TODO: Create a proper error if the category is not found.
+                .optional()?;
             let Some((cur_name, cur_color, cur_icon, builtin_i, cur_sort)) = row else {
                 return Ok(());
             };
@@ -260,32 +261,27 @@ pub async fn update(pool: &DbPool, id: &str, patch: CategoryPatch) -> Result<()>
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or(cur_icon);
-
-            conn.execute(
-                "UPDATE categories SET name = ?, color = ?, icon = ?, updated_at = ? WHERE id = ?",
-                rusqlite::params![new_name, new_color, new_icon, updated_at, id],
-            )
-            .db()?;
-
-            let payload = category_payload(
-                &id,
-                &new_name,
-                &new_color,
-                &new_icon,
-                builtin_i != 0,
-                cur_sort,
-                &updated_at,
-                None,
-            );
-            enqueue(
-                conn,
-                OutboxOp::Upsert,
-                OutboxEntity::Category,
-                &id,
-                &payload,
-            )
-            .db()?;
-
+            let n = tx
+                .execute(
+                    "UPDATE categories SET name = ?1, color = ?2, icon = ?3, updated_at = ?4
+                        WHERE id = ?5 AND (name IS NOT ?1 OR color IS NOT ?2 OR icon IS NOT ?3)",
+                    rusqlite::params![new_name, new_color, new_icon, updated_at, id],
+                )
+                .db()?;
+            if n > 0 {
+                let payload = category_payload(
+                    &id,
+                    &new_name,
+                    &new_color,
+                    &new_icon,
+                    builtin_i != 0,
+                    cur_sort,
+                    &updated_at,
+                    None,
+                );
+                enqueue(&tx, OutboxOp::Upsert, OutboxEntity::Category, &id, &payload).db()?;
+            }
+            tx.commit().db()?;
             Ok(())
         })
         .await?;
@@ -651,18 +647,19 @@ mod tests {
     }
 
     /// 绕过 `deleted_at IS NULL` 过滤直接读原始行（测软删语义必须能看到 tombstone）。
-    /// 返回 (name, color, icon, builtin, sort_order, deleted_at)。
+    /// 返回 (name, color, icon, builtin, sort_order, deleted_at, updated_at)。
+    #[allow(clippy::type_complexity)]
     async fn raw_cat(
         pool: &DbPool,
         id: &str,
-    ) -> Option<(String, String, String, i64, i64, Option<String>)> {
+    ) -> Option<(String, String, String, i64, i64, Option<String>, String)> {
         let id = id.to_string();
         pool.0
             .call(move |conn| {
                 use rusqlite::OptionalExtension;
                 let row = conn
                     .query_row(
-                        "SELECT name, color, icon, builtin, sort_order, deleted_at
+                        "SELECT name, color, icon, builtin, sort_order, deleted_at, updated_at
                            FROM categories WHERE id = ?1",
                         rusqlite::params![id],
                         |r| {
@@ -673,6 +670,7 @@ mod tests {
                                 r.get::<_, i64>(3)?,
                                 r.get::<_, i64>(4)?,
                                 r.get::<_, Option<String>>(5)?,
+                                r.get::<_, String>(6)?,
                             ))
                         },
                     )
@@ -860,6 +858,76 @@ mod tests {
             (got.name.as_str(), got.color.as_str(), got.icon.as_str()),
             ("改名", "#222222", "Moon"),
             "空白 patch 不得清掉任何字段"
+        );
+    }
+
+    /// 为什么测：`updated_at` 是跨设备 LWW 的仲裁者，它表示的应该是「内容最后一次
+    /// 变化」，不是「最后一次被写」。原值重提一遍若刷新它，这台设备就凭空赢下一次
+    /// 比较，把另一台真正改过的名字覆盖掉——用户自己敲的字没了。
+    ///
+    /// 后半段钉的是判断条件必须是「任一字段不同」而非「全部不同」：写成 AND 的话
+    /// 只改一个字段会整条失效，而「字段等于新值」那种断言在改之前也成立，看不出来。
+    #[tokio::test]
+    async fn update_with_unchanged_values_bumps_nothing() {
+        let pool = fresh_test_pool().await;
+        let cat = create(&pool, cat_input("工作", "#aaaaaa", "Star"))
+            .await
+            .unwrap();
+        let before_ts = raw_cat(&pool, &cat.id).await.unwrap().6;
+        let before_outbox = outbox_total(&pool).await;
+
+        // 三个字段原样重提
+        update(
+            &pool,
+            &cat.id,
+            CategoryPatch {
+                name: Some("工作".into()),
+                color: Some("#aaaaaa".into()),
+                icon: Some("Star".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            raw_cat(&pool, &cat.id).await.unwrap().6,
+            before_ts,
+            "无变化的更新不得刷新 updated_at —— 它会在 LWW 里凭空赢过对端的真实改动"
+        );
+        assert_eq!(
+            outbox_total(&pool).await,
+            before_outbox,
+            "无变化的更新不得入 outbox"
+        );
+
+        // 只改一个字段：必须生效
+        update(
+            &pool,
+            &cat.id,
+            CategoryPatch {
+                name: Some("本职".into()),
+                color: None,
+                icon: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let got = find_cat(&pool, &cat.id).await.expect("分类应仍在");
+        assert_eq!(
+            (got.name.as_str(), got.color.as_str(), got.icon.as_str()),
+            ("本职", "#aaaaaa", "Star"),
+            "只改一个字段也必须生效，其余不动"
+        );
+        assert_ne!(
+            raw_cat(&pool, &cat.id).await.unwrap().6,
+            before_ts,
+            "真实改动必须刷新 updated_at"
+        );
+        assert_eq!(
+            outbox_total(&pool).await,
+            before_outbox + 1,
+            "真实改动应恰好入一条 outbox"
         );
     }
 

--- a/src-tauri/src/sync/engine/pull.rs
+++ b/src-tauri/src/sync/engine/pull.rs
@@ -1,6 +1,7 @@
 //! Pull 路径：列 Drive 文件，按 modifiedTime 增量下载，按文件名分发到 merge_*。
 //! merge_* 都做 LWW（updated_at 字典序比较）+ idempotent upsert。
 
+use rusqlite::OptionalExtension;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -39,7 +40,6 @@ fn is_remote_newer<P: rusqlite::Params>(
     key: P,
     new: &str,
 ) -> rusqlite::Result<bool> {
-    use rusqlite::OptionalExtension;
     let cur: Option<String> = conn
         .query_row(select_updated_at_sql, key, |r| r.get(0))
         .optional()?;
@@ -694,7 +694,14 @@ where
         };
         let res = pool
             .0
-            .call(move |conn| apply(conn, row).map_err(tokio_rusqlite::Error::Rusqlite))
+            .call(move |conn| {
+                // 一行一个事务：`apply` 的 LWW 判断、行写入和它连带的 outbox / cascade
+                // 要么全落地要么全不落。半落地是不可恢复的——updated_at 一旦写成远端那个
+                // 值，下次拉到同一个文件 LWW 判断就不成立，剩下那半永远补不上。
+                let tx = conn.transaction().db()?;
+                apply(&tx, row).db()?;
+                tx.commit().db()
+            })
             .await;
         if let Err(e) = res {
             log::warn!("{entity} {label} merge 失败: {e}");
@@ -716,7 +723,7 @@ async fn merge_categories(pool: &DbPool, _device_id: &str, body: &[u8]) -> Resul
                     rusqlite::params![row.id],
                     |r| Ok((r.get(0)?, r.get(1)?)),
                 )
-                .ok();
+                .optional()?;
             let should_apply = match &cur {
                 None => true,
                 Some((cur_upd, _)) => row.updated_at.as_str() > cur_upd.as_str(),


### PR DESCRIPTION
Four write paths could fail without reporting it. Nothing changes for a user who never hits an error; what changes is what happens when one does.

## The bugs

**Saving without changing anything overwrote a real edit made elsewhere.** Open a group, leave the name alone, hit save. The row's timestamp moves to now and the row is queued for sync. Devices resolve conflicts by keeping the newer timestamp, so that empty save now outranks the rename you made on the laptop ten minutes ago, and the next sync puts the old name back. Re-assigning the category a group already has did the same thing.

**A multi-step write could stop halfway and stay that way.** Dragging categories into a new order writes one row per category, each committed on its own. If the fourth write fails, the first three keep their new positions, the rest keep their old ones, and the user gets an error on top of a list that is sorted halfway. Deleting a category is three steps — mark it deleted, queue that for sync, then move every app that was in it back to unclassified — with the same exposure: fail on the last step and those apps stay filed under a category that is gone.

**A failed query was indistinguishable from a deleted category.** Renaming a category starts by reading the current row. SQLite reports "no rows" and "the read failed" the same way, and the code treated both as "this category is gone" — a legitimate no-op, because another device may have deleted it. So a genuine read failure returned success to the frontend having written nothing. The UI shows the new name, the database does not have it, and no error was ever raised. Deleting had the same hole; reordering silently skipped that one category.

**In the sync path the same gap cannot heal itself.** Another device deletes the "Work" category. This machine applies it in two parts: mark the category deleted, then move every app that was in it back to unclassified. Only the first part is recorded as progress, because the category's timestamp is set to the remote one the moment it lands. If the second part fails, the next sync compares timestamps, concludes it is already up to date, and skips the row for good. Those apps stay attached to a category that no longer exists. Locally the user can click delete again; here nothing ever comes back for them.

## The fix

| Commit | |
|---|---|
| `d94866e` | `app_groups`: value guards on `rename` and `assign_category`; `restore_solo_group` takes `&Transaction` |
| `54fe5d8` | `categories::update`: transaction, value guard, `.optional()`, test |
| `a0fb3bd` | `categories::reorder` and `delete`: transaction, `.optional()` |
| `4608106` | `merge_lww_simple`: one transaction per merged row |

`restore_solo_group`'s signature is the only place the compiler now enforces the transaction. Everywhere else it is still a convention the caller has to follow. `cascade_category_deletion` deliberately keeps `&Connection`: tightening it would drag `merge_lww_simple`'s closure type along, which belongs in its own change.

## Worth a second look

- The new test's second half. A guard written with `AND` instead of `OR` passes every "the field now equals the new value" assertion while doing nothing at all. That is the trap it exists to catch.
- `merge_lww_simple` opening a transaction per row. Those statements each auto-committed before, so this replaces several implicit transactions with one and should not cost anything.

## Not fixed here

A row whose merge fails is still logged and skipped while the pull cursor advances, so it is not re-fetched until that file changes upstream again. The database ends up self-consistent but incomplete. Closing that gap means changing the cursor policy, which is a separate decision.

## Checked

`cargo test` 524 passed · `clippy --all-targets -D warnings` clean · `cargo fmt --check` clean. Each of the four commits compiles on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
