### PR TITLE
refactor(sync): stop merging app_categories files

### DIFF
--- a/src-tauri/src/repo/app_groups.rs
+++ b/src-tauri/src/repo/app_groups.rs
@@ -24,7 +24,7 @@
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::OptionalExtension;
 use serde::Serialize;
 
 use crate::error::{Error, Result};
@@ -903,38 +903,6 @@ pub async fn ensure_group(pool: &DbPool, process_name: &str) -> Result<()> {
             Ok(())
         })
         .await?;
-    Ok(())
-}
-
-/// Writes one `app_categories` row (`cat = None` soft-deletes) without touching
-/// the outbox. Only the sync pull path still calls this: the local mirror is no
-/// longer maintained, but rows echoed by older peers are still stored here.
-pub(crate) fn apply_app_category_change(
-    conn: &Connection,
-    process_name: &str,
-    category_id: Option<&str>,
-    now: &str,
-) -> rusqlite::Result<()> {
-    match category_id {
-        Some(cat) => {
-            conn.execute(
-                "INSERT INTO app_categories(process_name, category_id, updated_at, deleted_at)
-                 VALUES(?, ?, ?, NULL)
-                 ON CONFLICT(process_name) DO UPDATE SET
-                   category_id = excluded.category_id,
-                   updated_at  = excluded.updated_at,
-                   deleted_at  = NULL",
-                rusqlite::params![process_name, cat, now],
-            )?;
-        }
-        None => {
-            conn.execute(
-                "UPDATE app_categories SET deleted_at = ?, updated_at = ?
-                 WHERE process_name = ?",
-                rusqlite::params![now, now, process_name],
-            )?;
-        }
-    }
     Ok(())
 }
 

--- a/src-tauri/src/sync/engine/e2e_tests.rs
+++ b/src-tauri/src/sync/engine/e2e_tests.rs
@@ -770,8 +770,9 @@ async fn push_transient_failure_keeps_outbox_then_recovers() {
 /// A 端各表插一行 + 手工入 outbox（category / process_path / device / app_icon /
 /// app_group / app_group_member 六类）→ A sync 推文件 → B sync 拉回 → B 各表
 /// 字段逐一与 A 写入值相等。
-/// 第七个文件 app_categories 不是种子来的：本机不再维护那张表，push 在组或成员
-/// 变动时从「成员 ⋈ 组」现算一份给旧版本对端，这里连它的派生结果一并核对。
+/// 第七个文件 app_categories 是单向的：本机不再维护那张表，push 仍从「成员 ⋈ 组」
+/// 现算一份发给旧版本对端，pull 侧则完全不看它。这里两头都钉死——文件必须还在，
+/// B 的表必须是空的。
 /// 一条测试同时吃掉 push 构建侧的 build_* 与 pull 合并侧对应的 merge_*。
 // env 锁横跨整个测试(B merge app_icon 会写 icon 文件 cache,路径读
 // HINDSIGHT_DATA_DIR);#[tokio::test] 是单线程 runtime,持锁跨 await 不自死锁。
@@ -828,10 +829,6 @@ async fn metadata_seven_entities_cross_device_roundtrip() {
                 rusqlite::params![icon_ins, T_ICON],
             )
             .db()?;
-            // 组的 category 故意留 NULL:避免 merge_app_groups 的成员 mirror 在
-            // 本测试里被触发(mirror 会用"当下时间"改写 app_categories.updated_at,
-            // 而文件落盘顺序是 HashMap 随机序,字段级断言会变得不确定)。
-            // mirror 行为由 pull.rs 的直测单独钉死。
             conn.execute(
                 "INSERT INTO app_groups(id, display_name, category_id, updated_at, deleted_at)
                  VALUES('grp-e2e', 'Proc E2E 组', NULL, ?1, NULL)",
@@ -890,14 +887,14 @@ async fn metadata_seven_entities_cross_device_roundtrip() {
         Option<String>,
     );
     #[allow(clippy::type_complexity)]
-    let (cat, pp, dev, icon, grp, member, ac): (
+    let (cat, pp, dev, icon, grp, member, ac_rows): (
         CatRow,
         (String, String, String),
         DevRow,
         (Vec<u8>, String, Option<String>),
         (String, Option<String>, String, Option<String>),
         (String, String, Option<String>),
-        (String, String, Option<String>),
+        i64,
     ) = b
         .pool
         .0
@@ -971,15 +968,10 @@ async fn metadata_seven_entities_cross_device_roundtrip() {
                     |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
                 )
                 .db()?;
-            let ac = conn
-                .query_row(
-                    "SELECT category_id, updated_at, deleted_at
-                     FROM app_categories WHERE process_name = 'Proc-E2E'",
-                    [],
-                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
-                )
+            let ac_rows: i64 = conn
+                .query_row("SELECT COUNT(*) FROM app_categories", [], |r| r.get(0))
                 .db()?;
-            Ok((cat, pp, dev, icon, grp, member, ac))
+            Ok((cat, pp, dev, icon, grp, member, ac_rows))
         })
         .await
         .unwrap();
@@ -1035,22 +1027,18 @@ async fn metadata_seven_entities_cross_device_roundtrip() {
         ("grp-e2e".into(), T_MEMBER.into(), None),
         "app_group_members 行应逐字段一致"
     );
-    // 派生行的三个字段各对应一条派生规则:组没有分类 → 落到 'other' 且打墓碑;
-    // 时间戳取成员与组里较新的那个(T_MEMBER > T_GRP)。
-    assert_eq!(
-        ac,
-        ("other".into(), T_MEMBER.into(), Some(T_MEMBER.into())),
-        "app_categories 是派生出来的:组无分类时应是带墓碑的 'other' 行"
-    );
+    // 上面断言过 A 确实推了 app_categories 文件,这里断言 B 拉完之后一行都没进。
+    // 两条合起来才是「只发不收」:少任何一条都会让停发或者停收悄悄回归。
+    assert_eq!(ac_rows, 0, "app_categories 文件不应再被合并进本机");
 
     // pull 不回灌:B 侧合并远端数据不应产生任何 outbox 行(否则会推回死循环)
     assert_eq!(outbox_count(&b.pool).await, 0, "B pull 后 outbox 应仍为空");
 }
 
 /// 任务 7：OS 过滤 + 游标 stall 三段式。
-/// ① 只有 device-x 的 app_categories 文件、meta 未到 → OS 未知,游标不越过、表不写;
+/// ① 只有 device-x 的 process_paths 文件、meta 未到 → OS 未知,游标不越过、表不写;
 /// ② 补传同 OS meta → 下轮两个文件都合并,游标推进到 meta 的 modifiedTime;
-/// ③ 异 OS 设备 device-y 的 meta + app_categories → 数据文件标 handled 跳过
+/// ③ 异 OS 设备 device-y 的 meta + process_paths → 数据文件标 handled 跳过
 ///    (游标越过),之后永不再合并。
 #[tokio::test]
 async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
@@ -1058,12 +1046,12 @@ async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
     let dev = make_device("device-self", drive_store.clone()).await;
     let local_os = crate::platform::local_os_id();
 
-    let app_cat_body = |process: &str| {
-        serde_json::to_vec(&vec![crate::sync::payload::AppCategoryPayload {
+    let path_body = |process: &str| {
+        serde_json::to_vec(&vec![crate::sync::payload::ProcessPathPayload {
             process_name: process.to_string(),
-            category_id: "code".into(),
+            exe_path: format!("/Applications/{process}"),
+            seen_at: "2026-07-01T00:00:00Z".into(),
             updated_at: "2026-07-01T00:00:00Z".into(),
-            deleted_at: None,
         }])
         .unwrap()
     };
@@ -1079,14 +1067,14 @@ async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
         })
         .unwrap()
     };
-    let has_app_cat = |process: &'static str| {
+    let has_path = |process: &'static str| {
         let pool = dev.pool.clone();
         async move {
             pool.0
                 .call(move |conn| {
                     let n: i64 = conn
                         .query_row(
-                            "SELECT COUNT(*) FROM app_categories WHERE process_name = ?1",
+                            "SELECT COUNT(*) FROM process_paths WHERE process_name = ?1",
                             rusqlite::params![process],
                             |r| r.get(0),
                         )
@@ -1100,17 +1088,11 @@ async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
 
     // ① 数据文件先到,meta 缺席
     drive_store
-        .upsert_by_name(
-            "device.device-x.app_categories.json",
-            &app_cat_body("X-App"),
-        )
+        .upsert_by_name("device.device-x.process_paths.json", &path_body("X-App"))
         .await
         .unwrap();
     dev.engine.sync_now().await.unwrap();
-    assert!(
-        !has_app_cat("X-App").await,
-        "OS 未知时 app_categories 不应合并"
-    );
+    assert!(!has_path("X-App").await, "OS 未知时 process_paths 不应合并");
     assert_eq!(
         super::io::read_cursor(&dev.pool, "drive_files")
             .await
@@ -1132,7 +1114,7 @@ async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
     let t_meta_x = files[1].modified_time.clone(); // 升序:appcat(T1) < meta(T2)
     dev.engine.sync_now().await.unwrap();
     assert!(
-        has_app_cat("X-App").await,
+        has_path("X-App").await,
         "meta 到位且同 OS 后,数据文件应被合并"
     );
     assert_eq!(
@@ -1152,37 +1134,34 @@ async fn cross_os_filter_stalls_until_meta_then_skips_foreign_os() {
         .await
         .unwrap();
     drive_store
-        .upsert_by_name(
-            "device.device-y.app_categories.json",
-            &app_cat_body("Y-App"),
-        )
+        .upsert_by_name("device.device-y.process_paths.json", &path_body("Y-App"))
         .await
         .unwrap();
     let files = drive_store.list_appdata_files("").await.unwrap();
-    let t_appcat_y = files[3].modified_time.clone();
+    let t_path_y = files[3].modified_time.clone();
     dev.engine.sync_now().await.unwrap();
     assert!(
-        !has_app_cat("Y-App").await,
-        "异 OS 的 app_categories 永不合并(key 体系不同,合并有害)"
+        !has_path("Y-App").await,
+        "异 OS 的 process_paths 永不合并(key 体系不同,合并有害)"
     );
     assert_eq!(
         super::io::read_cursor(&dev.pool, "drive_files")
             .await
             .unwrap(),
-        t_appcat_y,
+        t_path_y,
         "异 OS 数据文件应标 handled 让游标越过(不是 stall)"
     );
 
     // 再 sync 一轮:游标已越过,该文件不再入列,结论不变
     dev.engine.sync_now().await.unwrap();
     assert!(
-        !has_app_cat("Y-App").await,
+        !has_path("Y-App").await,
         "游标越过后异 OS 文件永不再被拉取合并"
     );
 }
 
-/// 回归:同一轮 pull 内,引用方文件(app_categories / app_group_members)的
-/// modifiedTime 早于被引用文件(categories / app_groups)时,行不能丢。
+/// 回归:同一轮 pull 内,引用方文件(app_group_members)的 modifiedTime 早于被引用
+/// 文件(app_groups)时,行不能丢。
 ///
 /// 这正是 push HashMap 随机序下约 50% 概率触发的实锤 bug:修复前 Pass 2 按
 /// modifiedTime 升序直走,引用方先合并 → 行级 FK 失败仅 warn → handled=true
@@ -1196,7 +1175,7 @@ async fn pull_single_round_merges_children_even_when_files_precede_parents() {
     let drive = Arc::new(InMemoryDriveStore::new());
     let dev = make_device("device-self", drive.clone()).await;
 
-    // T1: 远端设备 meta,os = 本机 → 解锁 app_categories 的跨 OS 过滤
+    // T1: 远端设备 meta,os = 本机 → 解锁跨 OS 过滤
     let meta = serde_json::to_vec(&serde_json::json!({
         "deviceId": "device-x",
         "displayName": "Device X",
@@ -1212,21 +1191,7 @@ async fn pull_single_round_merges_children_even_when_files_precede_parents() {
         .await
         .unwrap();
 
-    // T2 / T3: 引用方文件先落 Drive(modifiedTime 更早)
-    drive
-        .upsert_by_name(
-            "device.device-x.app_categories.json",
-            serde_json::to_vec(&serde_json::json!([{
-                "processName": "ProcCat-FK",
-                "categoryId": "cat-fk",
-                "updatedAt": "2026-05-15T09:00:01Z",
-                "deletedAt": null,
-            }]))
-            .unwrap()
-            .as_slice(),
-        )
-        .await
-        .unwrap();
+    // T2: 引用方文件先落 Drive(modifiedTime 更早)
     drive
         .upsert_by_name(
             "device.device-x.app_group_members.json",
@@ -1242,25 +1207,7 @@ async fn pull_single_round_merges_children_even_when_files_precede_parents() {
         .await
         .unwrap();
 
-    // T4 / T5: 被引用文件后落 Drive
-    drive
-        .upsert_by_name(
-            "device.device-x.categories.json",
-            serde_json::to_vec(&serde_json::json!([{
-                "id": "cat-fk",
-                "name": "FK 分类",
-                "color": "#123456",
-                "icon": "Star",
-                "builtin": false,
-                "sortOrder": 42,
-                "updatedAt": "2026-05-15T09:00:03Z",
-                "deletedAt": null,
-            }]))
-            .unwrap()
-            .as_slice(),
-        )
-        .await
-        .unwrap();
+    // T3: 被引用文件后落 Drive
     drive
         .upsert_by_name(
             "device.device-x.app_groups.json",
@@ -1286,35 +1233,17 @@ async fn pull_single_round_merges_children_even_when_files_precede_parents() {
             .unwrap_or_else(|| panic!("Drive 应有 {name} 文件"))
     };
     assert!(
-        pos("device.device-x.app_categories.json") < pos("device.device-x.categories.json")
-            && pos("device.device-x.app_group_members.json")
-                < pos("device.device-x.app_groups.json"),
+        pos("device.device-x.app_group_members.json") < pos("device.device-x.app_groups.json"),
         "前置条件:引用方文件的 modifiedTime 必须早于被引用文件"
     );
 
     dev.engine.sync_now().await.expect("sync 应成功");
 
-    // 单轮之后四行必须全部落库(修复前两条引用方行被 FK 吃掉且永不再拉)
-    let (cat_n, ac_cat, grp_n, member_grp): (i64, Option<String>, i64, Option<String>) = dev
+    // 单轮之后两行必须全部落库(修复前引用方行被 FK 吃掉且永不再拉)
+    let (grp_n, member_grp): (i64, Option<String>) = dev
         .pool
         .0
         .call(|conn| {
-            let cat_n: i64 = conn
-                .query_row(
-                    "SELECT COUNT(*) FROM categories WHERE id = 'cat-fk' AND deleted_at IS NULL",
-                    [],
-                    |r| r.get(0),
-                )
-                .db()?;
-            let ac_cat: Option<String> = conn
-                .query_row(
-                    "SELECT category_id FROM app_categories
-                     WHERE process_name = 'ProcCat-FK' AND deleted_at IS NULL",
-                    [],
-                    |r| r.get(0),
-                )
-                .optional()
-                .db()?;
             let grp_n: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM app_groups WHERE id = 'grp-fk' AND deleted_at IS NULL",
@@ -1331,18 +1260,12 @@ async fn pull_single_round_merges_children_even_when_files_precede_parents() {
                 )
                 .optional()
                 .db()?;
-            Ok((cat_n, ac_cat, grp_n, member_grp))
+            Ok((grp_n, member_grp))
         })
         .await
         .unwrap();
 
-    assert_eq!(cat_n, 1, "categories 行应落库");
     assert_eq!(grp_n, 1, "app_groups 行应落库");
-    assert_eq!(
-        ac_cat.as_deref(),
-        Some("cat-fk"),
-        "app_categories 行不能因文件序早于 categories 而丢失"
-    );
     assert_eq!(
         member_grp.as_deref(),
         Some("grp-fk"),

--- a/src-tauri/src/sync/engine/pull.rs
+++ b/src-tauri/src/sync/engine/pull.rs
@@ -13,8 +13,8 @@ use crate::error::{Error, Result};
 use crate::storage::{utc_now_rfc3339, DbPool, SqliteResultExt};
 use crate::sync::auth::{self, TokenInfo};
 use crate::sync::payload::{
-    ActivityPayload, AppCategoryPayload, AppGroupMemberPayload, AppGroupPayload, AppIconPayload,
-    CategoryPayload, DeviceMetaPayload, ProcessPathPayload, TombstonePayload,
+    ActivityPayload, AppGroupMemberPayload, AppGroupPayload, AppIconPayload, CategoryPayload,
+    DeviceMetaPayload, ProcessPathPayload, TombstonePayload,
 };
 
 /// 解析一个 JSON 数组到 `Vec<T>`，但保留**每行容错**：单行解析失败仅打 warn 跳过，
@@ -57,9 +57,6 @@ enum ParsedFile {
         local_date: String,
     },
     Categories {
-        device_id: String,
-    },
-    AppCategories {
         device_id: String,
     },
     ProcessPaths {
@@ -109,9 +106,6 @@ fn parse_filename(name: &str) -> Option<ParsedFile> {
             local_date: day.to_string(),
         }),
         ["device", uuid, "categories", "json"] => Some(ParsedFile::Categories {
-            device_id: uuid.to_string(),
-        }),
-        ["device", uuid, "app_categories", "json"] => Some(ParsedFile::AppCategories {
             device_id: uuid.to_string(),
         }),
         ["device", uuid, "process_paths", "json"] => Some(ParsedFile::ProcessPaths {
@@ -311,7 +305,6 @@ pub(super) async fn flush_pull(inner: &Arc<Inner>) -> Result<()> {
         let device_id = match &parsed {
             ParsedFile::ActivityDay { device_id, .. }
             | ParsedFile::Categories { device_id }
-            | ParsedFile::AppCategories { device_id }
             | ParsedFile::ProcessPaths { device_id }
             | ParsedFile::AppIcons { device_id }
             | ParsedFile::AppGroups { device_id }
@@ -339,10 +332,7 @@ pub(super) async fn flush_pull(inner: &Arc<Inner>) -> Result<()> {
         // 跨 OS 合并要么完全无用（key 对不上），要么坏事（同名 key 撞车，把本机能用的路径覆盖掉，icon 提取失败）。
         // activities / app_icons 不过滤 —— 跨设备聚合活动是核心价值；icon 字节就是要让对方
         // 给从那台机器同步过来的 activity 行渲染图标用的。
-        if matches!(
-            parsed,
-            ParsedFile::AppCategories { .. } | ParsedFile::ProcessPaths { .. }
-        ) {
+        if matches!(parsed, ParsedFile::ProcessPaths { .. }) {
             match remote_device_os(&inner.pool, device_id).await {
                 // OS 已知且确实跨平台：跳过并标 handled（游标可越过——永远不该拉）。
                 Some(os) if os != local_os => {
@@ -402,9 +392,6 @@ pub(super) async fn flush_pull(inner: &Arc<Inner>) -> Result<()> {
             }
             ParsedFile::Categories { device_id } => {
                 merge_categories(&inner.pool, &device_id, &body).await
-            }
-            ParsedFile::AppCategories { device_id } => {
-                merge_app_categories(&inner.pool, &device_id, &body).await
             }
             ParsedFile::ProcessPaths { device_id } => {
                 merge_process_paths(&inner.pool, &device_id, &body).await
@@ -673,9 +660,8 @@ async fn merge_activities(
 ///    不能 capture 外部变量 —— 这样闭包是 `Copy`，能被循环里每行复用）
 /// 4. 单行 DB 错误降级 warn（per-line skip：一行坏数据不让对端 mirror 永久卡住）
 ///
-/// merge_app_icons / merge_app_groups / merge_categories / merge_activities 不走这个模板，
-/// 因为它们各自有合理的特殊路径（base64 文件 cache / member mirror / cascade
-/// delete / mirror 收敛）。
+/// merge_app_icons / merge_categories / merge_activities 不走这个模板，因为它们各自有
+/// 合理的特殊路径（base64 文件 cache / cascade delete / mirror 收敛）。
 async fn merge_lww_simple<T, F>(
     pool: &DbPool,
     entity: &'static str,
@@ -754,41 +740,6 @@ async fn merge_categories(pool: &DbPool, _device_id: &str, body: &[u8]) -> Resul
             if just_deleted {
                 crate::repo::categories::cascade_category_deletion(conn, &row.id, &row.updated_at)?;
             }
-            Ok(())
-        },
-    )
-    .await
-}
-
-async fn merge_app_categories(pool: &DbPool, _device_id: &str, body: &[u8]) -> Result<()> {
-    merge_lww_simple(
-        pool,
-        "app_category",
-        body,
-        |row: &AppCategoryPayload| (!row.process_name.is_empty()).then(|| row.process_name.clone()),
-        |conn, row: AppCategoryPayload| {
-            if !is_remote_newer(
-                conn,
-                "SELECT updated_at FROM app_categories WHERE process_name = ?1",
-                rusqlite::params![row.process_name],
-                &row.updated_at,
-            )? {
-                return Ok(());
-            }
-            conn.execute(
-                "INSERT INTO app_categories(process_name, category_id, updated_at, deleted_at)
-                 VALUES(?, ?, ?, ?)
-                 ON CONFLICT(process_name) DO UPDATE SET
-                   category_id = excluded.category_id,
-                   updated_at = excluded.updated_at,
-                   deleted_at = excluded.deleted_at",
-                rusqlite::params![
-                    row.process_name,
-                    row.category_id,
-                    row.updated_at,
-                    row.deleted_at
-                ],
-            )?;
             Ok(())
         },
     )
@@ -901,110 +852,40 @@ async fn merge_app_icons(pool: &DbPool, _device_id: &str, body: &[u8]) -> Result
 }
 
 async fn merge_app_groups(pool: &DbPool, _device_id: &str, body: &[u8]) -> Result<()> {
-    let rows: Vec<AppGroupPayload> = parse_rows("app_groups", body)?;
-    for row in rows {
-        if row.id.is_empty() {
-            continue;
-        }
-        // 拿当前本地 category_id 用来对比 —— 远端的分类 LWW 赢了之后，要 mirror 到
-        // app_categories 表里所有成员行（让 reports.rs 的 LEFT JOIN 仍能拿到正确分类）。
-        let id = row.id.clone();
-        // 单行失败降级为 warn —— 见 merge_activities 同模式注释。
-        let applied: Option<(Option<String>, Option<String>)> = match pool
-            .0
-            .call(move |conn| {
-                let prev: Option<(String, Option<String>)> = conn
-                    .query_row(
-                        "SELECT updated_at, category_id FROM app_groups WHERE id = ?1",
-                        rusqlite::params![row.id],
-                        |r| Ok((r.get(0)?, r.get(1)?)),
-                    )
-                    .ok();
-                let should_apply = match &prev {
-                    None => true,
-                    Some((cur_upd, _)) => row.updated_at.as_str() > cur_upd.as_str(),
-                };
-                if !should_apply {
-                    return Ok(None);
-                }
-                let prev_cat = prev.map(|(_, c)| c).unwrap_or(None);
-                conn.execute(
-                    "INSERT INTO app_groups(id, display_name, category_id, updated_at, deleted_at)
-                     VALUES(?, ?, ?, ?, ?)
-                     ON CONFLICT(id) DO UPDATE SET
-                       display_name = excluded.display_name,
-                       category_id  = excluded.category_id,
-                       updated_at   = excluded.updated_at,
-                       deleted_at   = excluded.deleted_at",
-                    rusqlite::params![
-                        row.id,
-                        row.display_name,
-                        row.category_id,
-                        row.updated_at,
-                        row.deleted_at
-                    ],
-                )
-                .db()?;
-                Ok(Some((prev_cat, row.category_id)))
-            })
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("app_group {id} merge 失败: {e}");
-                continue;
+    merge_lww_simple(
+        pool,
+        "app_group",
+        body,
+        |row: &AppGroupPayload| (!row.id.is_empty()).then(|| row.id.clone()),
+        |conn, row: AppGroupPayload| {
+            if !is_remote_newer(
+                conn,
+                "SELECT updated_at FROM app_groups WHERE id = ?1",
+                rusqlite::params![row.id],
+                &row.updated_at,
+            )? {
+                return Ok(());
             }
-        };
-
-        // 如果分类变了 —— 把新分类同步到组里所有 (active) 成员的 app_categories 行。
-        // 用本地的 process_name 列表（成员可能是 Mac 风格也可能是 Win 风格），
-        // 每行 enqueue outbox 让其它设备也拿到（同 OS 的对端会收到同样的 app_category 行）。
-        if let Some((prev_cat, next_cat)) = applied {
-            if prev_cat != next_cat {
-                let id_for_mirror = id.clone();
-                let next_for_mirror = next_cat.clone();
-                let now = utc_now_rfc3339();
-                if let Err(e) = pool
-                    .0
-                    .call(move |conn| {
-                        let members: Vec<String> = {
-                            let mut stmt = conn
-                                .prepare(
-                                    "SELECT process_name FROM app_group_members
-                                     WHERE group_id = ?1 AND deleted_at IS NULL",
-                                )
-                                .db()?;
-                            let rows = stmt
-                                .query_map(rusqlite::params![id_for_mirror], |r| {
-                                    r.get::<_, String>(0)
-                                })
-                                .db()?;
-                            let mut out = Vec::new();
-                            for r in rows {
-                                out.push(r.db()?);
-                            }
-                            out
-                        };
-                        for m in &members {
-                            // 远端推过来的分类变更：mirror 到 app_categories 但不入 outbox
-                            // —— 否则会形成「收到对端推 → 本端再推回去」的死循环。
-                            crate::repo::app_groups::apply_app_category_change(
-                                conn,
-                                m,
-                                next_for_mirror.as_deref(),
-                                &now,
-                            )?;
-                        }
-                        Ok(())
-                    })
-                    .await
-                {
-                    log::warn!("app_group {id} 分类 mirror 失败: {e}");
-                }
-            }
-        }
-    }
-    Ok(())
+            conn.execute(
+                "INSERT INTO app_groups(id, display_name, category_id, updated_at, deleted_at)
+                 VALUES(?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                   display_name = excluded.display_name,
+                   category_id  = excluded.category_id,
+                   updated_at   = excluded.updated_at,
+                   deleted_at   = excluded.deleted_at",
+                rusqlite::params![
+                    row.id,
+                    row.display_name,
+                    row.category_id,
+                    row.updated_at,
+                    row.deleted_at
+                ],
+            )?;
+            Ok(())
+        },
+    )
+    .await
 }
 
 async fn merge_app_group_members(pool: &DbPool, _device_id: &str, body: &[u8]) -> Result<()> {
@@ -1838,87 +1719,6 @@ mod tests {
         );
     }
 
-    // ───────── 任务 4:三个 LWW 模板 merge ─────────
-
-    /// merge_app_categories:较新覆盖(含墓碑)/ 较旧保留 / 同 updated_at 严格不覆盖 /
-    /// 本地无行插入。四个 key 一次 merge,期望互相独立。
-    #[tokio::test]
-    async fn merge_app_categories_lww_matrix() {
-        let pool = fresh_test_pool().await;
-        for (proc, ts) in [("A-newer", T_OLD), ("A-older", T_NEW), ("A-equal", T_MID)] {
-            exec_sql(
-                &pool,
-                "INSERT INTO app_categories(process_name, category_id, updated_at, deleted_at)
-                 VALUES(?1, 'code', ?2, NULL)",
-                vec![s(proc), s(ts)],
-            )
-            .await;
-        }
-        let body = serde_json::to_vec(&vec![
-            // 远端更新 + 墓碑 → 覆盖
-            AppCategoryPayload {
-                process_name: "A-newer".into(),
-                category_id: "fun".into(),
-                updated_at: T_MID.into(),
-                deleted_at: Some(T_MID.into()),
-            },
-            // 远端较旧 → 保留本地
-            AppCategoryPayload {
-                process_name: "A-older".into(),
-                category_id: "fun".into(),
-                updated_at: T_MID.into(),
-                deleted_at: None,
-            },
-            // 同 updated_at → 严格 > 不成立,不覆盖
-            AppCategoryPayload {
-                process_name: "A-equal".into(),
-                category_id: "fun".into(),
-                updated_at: T_MID.into(),
-                deleted_at: None,
-            },
-            // 本地无行 → 插入
-            AppCategoryPayload {
-                process_name: "A-missing".into(),
-                category_id: "fun".into(),
-                updated_at: T_OLD.into(),
-                deleted_at: None,
-            },
-        ])
-        .unwrap();
-        merge_app_categories(&pool, REMOTE_DEV, &body)
-            .await
-            .unwrap();
-
-        let get = |p: &'static str| {
-            read_row(
-                &pool,
-                "SELECT category_id, updated_at, deleted_at FROM app_categories WHERE process_name = ?1",
-                p,
-                3,
-            )
-        };
-        assert_eq!(
-            get("A-newer").await.unwrap(),
-            vec![s("fun"), s(T_MID), s(T_MID)],
-            "远端较新应覆盖(含墓碑落地)"
-        );
-        assert_eq!(
-            get("A-older").await.unwrap(),
-            vec![s("code"), s(T_NEW), None],
-            "远端较旧应保留本地"
-        );
-        assert_eq!(
-            get("A-equal").await.unwrap(),
-            vec![s("code"), s(T_MID), None],
-            "同 updated_at 必须严格不覆盖(平局本地赢)"
-        );
-        assert_eq!(
-            get("A-missing").await.unwrap(),
-            vec![s("fun"), s(T_OLD), None],
-            "本地缺行应插入"
-        );
-    }
-
     /// merge_process_paths:同一套 LWW 矩阵(该表无墓碑列,验证 exe_path/seen_at)。
     #[tokio::test]
     async fn merge_process_paths_lww_matrix() {
@@ -2044,99 +1844,6 @@ mod tests {
             vec![s("g2"), s(T_MID), None],
             "本地缺行应插入"
         );
-    }
-
-    // ───────── 任务 5:merge_app_groups 的成员 mirror ─────────
-
-    /// 远端组换分类 → 本地 app_categories 里该组全部 **active** 成员跟着换,
-    /// 软删成员不动;mirror 不回灌 outbox(远端来的变更再推回去会死循环);
-    /// 同 body 重复 merge 被 LWW gate 挡住,mirror 不再触发。
-    #[tokio::test]
-    async fn merge_app_groups_mirrors_active_members_without_outbox() {
-        let pool = fresh_test_pool().await;
-        exec_sql(
-            &pool,
-            "INSERT INTO app_groups(id, display_name, category_id, updated_at, deleted_at)
-             VALUES('grp', '编辑器', 'code', ?1, NULL)",
-            vec![s(T_OLD)],
-        )
-        .await;
-        // m1/m2 active,m3 软删(mirror 必须跳过它)
-        for (proc, deleted) in [("m1", None), ("m2", None), ("m3", s(T_OLD))] {
-            exec_sql(
-                &pool,
-                "INSERT INTO app_group_members(process_name, group_id, updated_at, deleted_at)
-                 VALUES(?1, 'grp', ?2, ?3)",
-                vec![s(proc), s(T_OLD), deleted],
-            )
-            .await;
-            exec_sql(
-                &pool,
-                "INSERT INTO app_categories(process_name, category_id, updated_at, deleted_at)
-                 VALUES(?1, 'code', ?2, NULL)",
-                vec![s(proc), s(T_OLD)],
-            )
-            .await;
-        }
-
-        let body = serde_json::to_vec(&vec![AppGroupPayload {
-            id: "grp".into(),
-            display_name: "编辑器".into(),
-            category_id: Some("fun".into()),
-            updated_at: T_MID.into(),
-            deleted_at: None,
-        }])
-        .unwrap();
-        merge_app_groups(&pool, REMOTE_DEV, &body).await.unwrap();
-
-        // 组本体换分类
-        let grp = read_row(
-            &pool,
-            "SELECT category_id, updated_at FROM app_groups WHERE id = ?1",
-            "grp",
-            2,
-        )
-        .await
-        .unwrap();
-        assert_eq!(grp, vec![s("fun"), s(T_MID)]);
-
-        // active 成员的 app_categories 全部 mirror 到新分类
-        let cat_of = |p: &'static str| {
-            read_row(
-                &pool,
-                "SELECT category_id FROM app_categories WHERE process_name = ?1",
-                p,
-                1,
-            )
-        };
-        assert_eq!(cat_of("m1").await.unwrap(), vec![s("fun")]);
-        assert_eq!(cat_of("m2").await.unwrap(), vec![s("fun")]);
-        assert_eq!(
-            cat_of("m3").await.unwrap(),
-            vec![s("code")],
-            "软删成员不参与 mirror"
-        );
-        assert!(
-            outbox_entries(&pool).await.is_empty(),
-            "远端推来的变更 mirror 后不得回灌 outbox(防推回死循环)"
-        );
-
-        // 重复 merge 同 body:LWW 平局 → 组不 apply → mirror 不重跑。
-        // 观察手法:先手动把 m1 改走,若 mirror 重跑会把它改回 'fun'。
-        exec_sql(
-            &pool,
-            "UPDATE app_categories SET category_id = 'design', updated_at = ?1
-             WHERE process_name = 'm1'",
-            vec![s(T_NEW)],
-        )
-        .await;
-        merge_app_groups(&pool, REMOTE_DEV, &body).await.unwrap();
-        assert_eq!(
-            cat_of("m1").await.unwrap(),
-            vec![s("design")],
-            "同 body 重复 merge 不得再次触发 mirror"
-        );
-        assert!(outbox_entries(&pool).await.is_empty());
     }
 
     // ───────── 任务 8:merge_app_icons(DB 侧) ─────────


### PR DESCRIPTION
We stop receiving a table nobody reads.

## What was happening

`app_categories` maps a process name to a category. It predates app groups, and since v0.7.0 nothing reads it — the category pages classify through `app_group_members ⋈ app_groups` instead. Local writes stopped in v0.8.23.

Sync did not get the message. Two paths still filled the table on every pull:

- the merge for `device.<id>.app_categories.json`;
- a mirror inside `merge_app_groups` that rewrote every member row whenever a peer changed a group's category.

So a table nobody queries kept growing, kept a stale copy of every process name the account has ever seen, and kept a second way for a process name to come back after being deleted.

## What changes

Both paths are gone. `device.<id>.app_categories.json` now falls through as an unrecognised filename, which means the pull skips it without even downloading it.

Push is deliberately untouched. The file is still derived and uploaded, because peers older than v0.7.0 classify from it. Retiring that side cuts those devices off from category sync, which is a product decision with a release note attached, so it is its own change.

Deleting the mirror had a side effect worth calling out. It was the only reason `merge_app_groups` could not use `merge_lww_simple`: the closure needed the group's previous category to decide whether to rewrite the members. With that gone the whole function collapses into a template call like its four siblings, and the template's list of exceptions is one shorter. It also picks up the shared last-write-wins helper, whose lookup distinguishes a missing row from a failed query — the hand-rolled version did not.

## Tests

Three end-to-end tests used `app_categories` as a vehicle for mechanisms that are still live, so they were re-pointed rather than deleted:

- the cross-OS filter, including the case where the peer's OS is unknown and the cursor must not advance, now rides on `process_paths`, which is the last file kind that filter applies to;
- the parent-before-child ordering regression now rests on `app_group_members` and `app_groups` alone, which still have a real foreign key between them;
- the round-trip test asserts the asymmetry directly: the file must still be published, and the table must stay empty afterwards. Either half regressing fails the test.

## Checked

`cargo test` 522 passed · `clippy --all-targets -D warnings` clean · `cargo fmt --check` clean. Net −355 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
